### PR TITLE
Check for apertium-lex-tools in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AC_PROG_AWK
 PKG_CHECK_MODULES(APERTIUM, apertium >= 3.7.2)
 PKG_CHECK_MODULES(LTTOOLBOX, lttoolbox >= 3.5.4)
 PKG_CHECK_MODULES(CG3, cg3 >= 1.3.3)
+PKG_CHECK_MODULES(APERTIUM_LEX_TOOLS, apertium-lex-tools >= 0.2.2)
 
 AC_PATH_PROGS(ZCAT, [gzcat zcat], [false])
 AS_IF([test x$ZCAT = xfalse], [AC_MSG_ERROR([You don't have zcat nor gzcat installed])])


### PR DESCRIPTION
Makefile.am calls `lrx-comp`, so configure should require apertium-lex-tools.